### PR TITLE
made change withtout renaming repo in git / package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TipLink SDK
+# TipLink API
 
 [Full Documentation](https://docs.tiplink.io)
 
@@ -13,11 +13,11 @@ TipLink offers the benefits of decentralization and self-custody without worryin
 
 # Basic Installation instructions
 ```bash
-npm install @tiplink/sdk
+npm install @tiplink/api
 ```
 Import Instructions
 ```js
-import { Tiplink } from '@tiplink/sdk';
+import { Tiplink } from '@tiplink/api';
 ```
 Create a tiplink
 ```js

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@tiplink/sdk",
+  "name": "@tiplink/api",
   "version": "0.0.3",
-  "description": "SDK for creating and sending TipLinks",
+  "description": "Api for creating and sending TipLinks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
Needs to be publishing to npm under 'tiplink/api', in addition to deprecating the sdk. 